### PR TITLE
Fix: Swap values of objects instead of entire objects"

### DIFF
--- a/app.js
+++ b/app.js
@@ -73,10 +73,14 @@ window.addEventListener("load",()=>{
 })
 
 swap.addEventListener('click',(e)=>{
-    console.log("hekod");
-    let temp = fromcurr;
-    fromcurr = tocurr;
-    tocurr= temp;
+    let tempValue = fromcurr.value;
+    fromcurr.value = tocurr.value; 
+    tocurr.value = tempValue;      
+    
+   
+    updateFlag(fromcurr);
+    updateFlag(tocurr);
+    
     
     updateExchangeRate();
 })


### PR DESCRIPTION
fixed #1 
The modified code swaps only the value property of the objects, preserving their identity and any associated references. This is a more targeted and potentially safer approach